### PR TITLE
removing looping that will be deprecated on 2.11 version.

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -8,11 +8,10 @@
 
 - name: Install packages required to create virtualenv
   apt:
-    name: "{{ item }}"
+    name: "{{ venv_packages }}"
     state: present
     update_cache: yes
     cache_valid_time: "{{ apt_cache_time }}"
-  with_items: "{{ venv_packages }}"
 
 - name: Create virtualenv
   command: virtualenv --python={{ venv_python }} {{ venv }}


### PR DESCRIPTION
On my project i'm receiving this alert from ansible "Invoking "apt" only once while using a loop via 
squash_actions is deprecated. Instead of using a loop to supply multiple items 
and specifying `name: "{{ item }}"`, please use `name: '{{ venv_packages }}'` 
and remove the loop.", so I just adjust to how ansible expect it.